### PR TITLE
Update to Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "transform-async-to-generator"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
   "author": "Chris Shepherd <chris.shepherd@uk.tesco.com>",
   "license": "MIT",
   "devDependencies": {
-    "babel": "^5.8.23",
+    "babel-cli": "^6.11.4",
     "babel-eslint": "^4.1.1",
+    "babel-plugin-transform-async-to-generator": "^6.8.0",
+    "babel-polyfill": "^6.13.0",
+    "babel-preset-es2015": "^6.13.2",
+    "babel-register": "^6.11.6",
     "eslint": "^1.3.1",
     "express": "^4.13.3",
     "jasmine": "^2.3.2",

--- a/specs/helpers/babel.js
+++ b/specs/helpers/babel.js
@@ -1,1 +1,2 @@
-require('babel/register');
+require('babel-polyfill');
+require('babel-register');

--- a/specs/index-spec.js
+++ b/specs/index-spec.js
@@ -19,7 +19,7 @@ describe('express-async-wrap', function() {
         results.push(makeResult(`test${i}`));
       }
 
-      res.send((await* results).join());
+      res.send((await Promise.all(results)).join());
     }));
 
     request(app)


### PR DESCRIPTION
This fixes #1. In Babel 6 the default export is no longer incorrectly exported as `module.exports`.
Babel users of this library will not notice this change, because Babel let's you _import_ the module the same way. But for users of ES5 and TypeScript this is a breaking change:

#### ES5
```js
// before
const wrap = require('express-async-wrap')
// now
const wrap = require('express-async-wrap').default
```
#### TypeScript
```ts
// before
import wrap = require('express-async-wrap')
// after
import wrap from 'express-async-wrap'
```